### PR TITLE
Move IO flush hack from ttyServer to emscriptenHack

### DIFF
--- a/src/emscriptenHack.ts
+++ b/src/emscriptenHack.ts
@@ -27,14 +27,22 @@ export const emscriptenHack = (client: Client) => {
   if (self.ENV) self.ENV["TERM"] = "xterm-256color";
 
   const buf: number[] = [];
+  let flushed = true;
 
   const myGetchar = () => {
     if (buf.length == 0) {
-      buf.push(...client.onRead());
+      if (flushed) {
+        buf.push(...client.onRead());
+        flushed = false;
+      } else {
+        flushed = true;
+        return null;
+      }
     }
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const c = buf.shift()!;
-    return c >= 0 ? (c < 128 ? c : c - 256) : null;
+    return c < 128 ? c : c - 256;
   };
 
   const myPutchar = (_tty: any, val: number | null) => {

--- a/src/ttyServer.ts
+++ b/src/ttyServer.ts
@@ -44,7 +44,7 @@ export class TtyServer {
     });
 
     slave.onReadable(() => {
-      this.toWorkerBuf.push(...slave.read(), -1);
+      this.toWorkerBuf.push(...slave.read());
 
       switch (this.state) {
         case "poll":


### PR DESCRIPTION
Previously, ttyServer.onRead returned -1 which meant IO flush or EOF. This is for the behavior of get_char of Emscripten internal. However, this hack is Emscripten-specific, so it would be good to handle it in emscriptenHack instead of ttyServer.

Fixes #1