### PR TITLE
`select(2)` should return zero when timed out

### DIFF
--- a/emscripten-pty.js
+++ b/emscripten-pty.js
@@ -168,7 +168,7 @@ Object.assign(Lib, {
         // If so, that means it called into the PTY and the buffer was empty.
         if (result === -{{{ 1000 + cDefs.EAGAIN }}}) {
             // Wait for the PTY to become readable and try again.
-            PTY_waitForReadable(ok => wakeUp(ok ? impl() : result));
+            PTY_waitForReadable(ok => wakeUp(ok ? impl() : 0));
         } else {
             wakeUp(result);
         }


### PR DESCRIPTION
`select(2)` should return 0 successfully on timeout.

https://man7.org/linux/man-pages/man2/select.2.html
> The return value may be zero if the timeout expired before any file descriptors became ready.

Previously, it returned -1 with errno 1006, which is a xterm-pty internal variant of EAGAIN.
 
