### PR TITLE
Add malloc as explicit dependency of atomic wait

### DIFF
--- a/emscripten-pty.js
+++ b/emscripten-pty.js
@@ -132,7 +132,7 @@ Object.assign(Lib, {
 
     $PTY_atomicIndex: 0,
 
-    $PTY_waitForReadableWithAtomic__deps: ['$PTY_waitForReadableWithAtomicImpl', '$PTY_atomicIndex'],
+    $PTY_waitForReadableWithAtomic__deps: ['$PTY_waitForReadableWithAtomicImpl', '$PTY_atomicIndex', 'malloc'],
     $PTY_waitForReadableWithAtomic: (callback) => {
         if (!PTY_atomicIndex) {
             PTY_atomicIndex = _malloc(4) >> 2;


### PR DESCRIPTION
In larger apps `malloc` is already included in JS as it's required by something else, so larger apps happened to build successfully as-is, but smaller examples failed.

Add it as an explicit dependency to fix those cases too.

Should fix #30 (haven't tested myself though).