### PR TITLE
FIX: EOF not being properly reported

### DIFF
--- a/emscripten-pty.js
+++ b/emscripten-pty.js
@@ -182,6 +182,11 @@ Object.assign(Lib, {
                     case 0: /* ready */
                         const inner = xterm_pty_old_fd_read(fd, iov, iovcnt, pnum);
                         if (inner == {{{ 1000 + cDefs.EAGAIN }}}) {
+                          // Despite the fact that we are in the readable state,
+                          // TTY.read returned our variant of EAGAIN again.
+                          // This means that a readable state was due to EOF.
+                          // Therefore, we return 0 to indicate that
+                          // it has successfully read 0 bytes (i.e., EOF).
                           HEAP32[(pnum)>>2] = 0;
                           wakeUp(0);
                         } else {

--- a/emscripten-pty.js
+++ b/emscripten-pty.js
@@ -180,7 +180,13 @@ Object.assign(Lib, {
             PTY_waitForReadable((type) => {
                 switch (type) {
                     case 0: /* ready */
-			wakeUp(xterm_pty_old_fd_read(fd, iov, iovcnt, pnum));
+                        const inner = xterm_pty_old_fd_read(fd, iov, iovcnt, pnum);
+                        if (inner == {{{ 1000 + cDefs.EAGAIN }}}) {
+                          HEAP32[(pnum)>>2] = 0;
+                          wakeUp(0);
+                        } else {
+                          wakeUp(inner);
+                        }
                         break;
                     case 1: /* interrupted */
                         wakeUp({{{ cDefs.EINTR }}});


### PR DESCRIPTION
fixes #47. PLEASE TEST as I am very new to wasm and emscripten as well as JS itself :). I found that two 1006 codes were raised where EOF should have occurred and based on that just patched `fd_read` to handle that case and report a read of `0`.